### PR TITLE
EPMUII-5984 Improved 3d settings tooltips

### DIFF
--- a/src/ui/Panels/Tabs/Mode3dSelectionTabs.jsx
+++ b/src/ui/Panels/Tabs/Mode3dSelectionTabs.jsx
@@ -20,6 +20,7 @@ import { RadiusProperty } from '../Properties3d/RadiusProperty';
 import { DepthProperty } from '../Properties3d/DepthProperty';
 import { FlexRow } from '../../Layout/FlexRow';
 import { UIButton } from '../../Button/Button';
+import { MuiStyledTooltip } from './atoms/CustomizedTooltip';
 
 export function Mode3dSelectionTabs() {
   const dispatch = useDispatch();
@@ -49,10 +50,18 @@ export function Mode3dSelectionTabs() {
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
         <p className={css.caption}>3D mode selection</p>
         <Tabs value={mode3d} onChange={handleChange} aria-label="basic tabs example" textColor="inherit" indicatorColor="secondary">
-          <Tab label="I" value={Modes3d.ISO} />
-          <Tab label="V" value={Modes3d.RAYCAST} />
-          <Tab label="M" value={Modes3d.RAYFAST} />
-          <Tab label="E" value={Modes3d.EREASER} />
+          <MuiStyledTooltip arrow title=" Show just barrier value surface, 1st ray intersection">
+            <Tab label="I" value={Modes3d.ISO} />
+          </MuiStyledTooltip>
+          <MuiStyledTooltip arrow title="Show complete 3d volumetric rendering">
+            <Tab label="V" value={Modes3d.RAYCAST} />
+          </MuiStyledTooltip>
+          <MuiStyledTooltip arrow title="Show maximum projection rendering">
+            <Tab label="M" value={Modes3d.RAYFAST} />
+          </MuiStyledTooltip>
+          <MuiStyledTooltip arrow title="Special volume eraser tool">
+            <Tab label="E" value={Modes3d.EREASER} />
+          </MuiStyledTooltip>
         </Tabs>
       </Box>
       <TabPanel index={Modes3d.ISO} value={mode3d}>

--- a/src/ui/Panels/Tabs/Mode3dSelectionTabs.jsx
+++ b/src/ui/Panels/Tabs/Mode3dSelectionTabs.jsx
@@ -20,7 +20,7 @@ import { RadiusProperty } from '../Properties3d/RadiusProperty';
 import { DepthProperty } from '../Properties3d/DepthProperty';
 import { FlexRow } from '../../Layout/FlexRow';
 import { UIButton } from '../../Button/Button';
-import { MuiStyledTooltip } from './atoms/CustomizedTooltip';
+import { MuiStyledTooltip } from '../../Tooltip/atoms/MuiStyledTooltip';
 
 export function Mode3dSelectionTabs() {
   const dispatch = useDispatch();

--- a/src/ui/Panels/Tabs/atoms/CustomizedTooltip.jsx
+++ b/src/ui/Panels/Tabs/atoms/CustomizedTooltip.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Tooltip, { tooltipClasses } from '@mui/material/Tooltip';
+import { styled } from '@mui/material/styles';
+
+export const MuiStyledTooltip = styled(({ className, ...props }) => <Tooltip {...props} classes={{ popper: className }} />)(() => ({
+  [`& .${tooltipClasses.tooltip}`]: {
+    display: 'inline-block',
+    maxWidth: 500,
+    zIndex: 1000,
+    borderRadius: '5px',
+    boxShadow: '0 0 8px 0 rgba(0, 0, 0, 0.14)',
+    padding: '10px 15px',
+    backgroundColor: '#46494e',
+    opacity: 0.98,
+    fontSize: '16px',
+    lineHeight: '20px',
+    color: 'white',
+    whiteSpace: 'pre',
+  },
+}));

--- a/src/ui/Tooltip/atoms/MuiStyledTooltip.jsx
+++ b/src/ui/Tooltip/atoms/MuiStyledTooltip.jsx
@@ -16,5 +16,6 @@ export const MuiStyledTooltip = styled(({ className, ...props }) => <Tooltip {..
     lineHeight: '20px',
     color: 'white',
     whiteSpace: 'pre',
+    fontFamily: "'Inter', 'sans-serif'",
   },
 }));


### PR DESCRIPTION
https://jira.epam.com/jira/browse/EPMUII-5984
I used styled and a brand new tooltip from Material UI because the component with the Tabs was build with MUI, after few tries to use our custom tooltip on this ones it doesn`t work properly and it throws errors because of the MUI library.
I left it as an atom which maybe you will use in the future development on Material UI components which will need this type of tooltip.